### PR TITLE
Added support for iv as Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,12 +20,20 @@ function CryptoStream(cipher, opts) {
 util.inherits(CryptoStream, Transform);
 
 CryptoStream.prototype._transform = function(chunk, encoding, callback) {
-  this.push(this._cipher.update(chunk, this.inputEncoding, this.outputEncoding));
+  try {
+    this.push(this._cipher.update(chunk, this.inputEncoding, this.outputEncoding));
+  } catch (err) {
+    return callback(err);
+  }
   callback();
 };
 
 CryptoStream.prototype._flush = function(callback) {
-  this.push(this._cipher.final(this.outputEncoding));
+  try {
+    this.push(this._cipher.final(this.outputEncoding));
+  } catch (err) {
+    return callback(err);
+  }
   callback();
 };
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ CryptoStream.prototype._flush = function(callback) {
 };
 
 CryptoStream.prototype.parseOptions = function(opts) {
-  opts.iv = typeof opts.iv === 'string' ? opts.iv : '';
+  opts.iv = (opts.iv instanceof Buffer || typeof opts.iv === 'string') ? opts.iv : '';
 
   return opts;
 };


### PR DESCRIPTION
http://nodejs.org/api/crypto.html#crypto_crypto_createcipheriv_algorithm_key_iv

"key and iv must be 'binary' encoded strings _or_ buffers"
